### PR TITLE
Enable DinD rootless for Customer Testing

### DIFF
--- a/azure-east/arc-system/application-runner-scale-set-dind.yaml
+++ b/azure-east/arc-system/application-runner-scale-set-dind.yaml
@@ -1,0 +1,90 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners-d-in-d
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: arc
+  source:
+    repoURL: ghcr.io/actions/actions-runner-controller-charts
+    targetRevision: 0.6.1
+    chart: gha-runner-scale-set
+    helm:
+      releaseName: "arc-runners-d-in-d"
+      values: |
+        githubConfigUrl: "https://github.com/containerization-vgroup"
+        githubConfigSecret: "pre-defined-secret"
+        controllerServiceAccount:
+          namespace: arc-system
+          name: arc-gha-rs-controller
+        minRunners: 2
+        maxRunners: 10
+        runnerGroup: "arc-runners-d-in-d"
+        listenerTemplate:
+          spec:
+            containers:
+            - name: listener
+          metadata:
+            annotations:
+              "prometheus.io/scrape": "true"
+              "prometheus.io/path": "/metrics"
+              "prometheus.io/port": "8080"       
+        template:
+          spec:
+            containers:
+              - name: runner
+                image: ghcr.io/actions/actions-runner:latest
+                command: ["/home/runner/run.sh"]
+                env:
+                - name: runtime
+                  value: "kubernetes"
+                - name: DOCKER_HOST
+                  value: "tcp://localhost:2375"
+                volumeMounts:
+                - name: work
+                  mountPath: /home/runner/work
+                - name: docker-socket
+                  mountPath: /var/run/docker.sock
+            volumes:
+            - name: work
+              emptyDir: {}
+            - name: docker-socket
+              emptyDir: {} # Using emptyDir to support rootless mode
+            initContainers:
+            - name: dind-rootless
+              image: docker:20.10-dind-rootless
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                privileged: false
+              volumeMounts:
+              - name: docker-socket
+                mountPath: /var/run/docker.sock
+              env:
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: DOCKER_HOST
+                value: "tcp://localhost:2375"
+              - name: DOCKER_DRIVER
+                value: "overlay2"
+      version: v3
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners-d-in-d
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+    - Validate=false
+    - CreateNamespace=true
+    - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/azure-east/arc-system/application-runner-scale-set-dind.yaml
+++ b/azure-east/arc-system/application-runner-scale-set-dind.yaml
@@ -1,90 +1,92 @@
-apiVersion: argoproj.io/v1alpha1
-kind: Application
+apiVersion: argoproj.io/v1alpha1  # API version for Argo CD Application
+kind: Application  # Kind of the resource
 metadata:
-  name: arc-runners-d-in-d
-  namespace: argocd
+  name: arc-runners-d-in-d  # Name of the Argo CD application
+  namespace: argocd  # Namespace where Argo CD application resides
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io  # Ensures resources are cleaned up when the application is deleted
 spec:
-  project: arc
+  project: arc  # Project in Argo CD where the application belongs
   source:
-    repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.6.1
-    chart: gha-runner-scale-set
+    repoURL: ghcr.io/actions/actions-runner-controller-charts  # Repository URL for the Helm chart
+    targetRevision: 0.6.1  # Version of the Helm chart to use
+    chart: gha-runner-scale-set  # Helm chart name
     helm:
-      releaseName: "arc-runners-d-in-d"
-      values: |
-        githubConfigUrl: "https://github.com/containerization-vgroup"
-        githubConfigSecret: "pre-defined-secret"
+      releaseName: "arc-runners-d-in-d"  # Override the Helm release name
+      values: |  # Inline Helm values for customizing the deployment
+        githubConfigUrl: "https://github.com/containerization-vgroup"  # URL for the GitHub configuration
+        githubConfigSecret: "pre-defined-secret"  # Kubernetes secret with GitHub token
         controllerServiceAccount:
-          namespace: arc-system
-          name: arc-gha-rs-controller
-        minRunners: 2
-        maxRunners: 10
-        runnerGroup: "arc-runners-d-in-d"
+          namespace: arc-system  # Namespace for the controller's service account
+          name: arc-gha-rs-controller  # Name of the service account
+        minRunners: 2  # Minimum number of runners
+        maxRunners: 10  # Maximum number of runners
+        runnerGroup: "arc-runners-d-in-d"  # GitHub runner group name
         listenerTemplate:
           spec:
             containers:
-            - name: listener
+            - name: listener  # Name of the listener container
           metadata:
             annotations:
-              "prometheus.io/scrape": "true"
-              "prometheus.io/path": "/metrics"
-              "prometheus.io/port": "8080"       
+              "prometheus.io/scrape": "true"  # Enable Prometheus scraping
+              "prometheus.io/path": "/metrics"  # Metrics path for Prometheus
+              "prometheus.io/port": "8080"  # Port for Prometheus to scrape
         template:
           spec:
             containers:
-              - name: runner
-                image: ghcr.io/actions/actions-runner:latest
-                command: ["/home/runner/run.sh"]
+              - name: runner  # Name of the runner container
+                image: ghcr.io/actions/actions-runner:latest  # Docker image for the runner
+                command: ["/home/runner/run.sh"]  # Command to run inside the container
                 env:
                 - name: runtime
-                  value: "kubernetes"
+                  value: "kubernetes"  # Set runtime environment
                 - name: DOCKER_HOST
-                  value: "tcp://localhost:2375"
+                  value: "tcp://localhost:2375"  # Set Docker host for DIND
                 volumeMounts:
                 - name: work
-                  mountPath: /home/runner/work
+                  mountPath: /home/runner/work  # Mount path for work directory
                 - name: docker-socket
-                  mountPath: /var/run/docker.sock
+                  mountPath: /var/run/docker.sock  # Mount path for Docker socket
             volumes:
             - name: work
-              emptyDir: {}
+              emptyDir: {}  # Create an empty directory volume for work
             - name: docker-socket
-              emptyDir: {} # Using emptyDir to support rootless mode
+              emptyDir: {}  # Create an empty directory volume for Docker socket (supports rootless mode)
             initContainers:
-            - name: dind-rootless
-              image: docker:20.10-dind-rootless
+            - name: dind-rootless  # Name of the init container for DIND rootless
+              image: docker:20.10-dind-rootless  # Docker image for DIND rootless
               securityContext:
-                runAsUser: 1000
-                runAsGroup: 1000
-                privileged: false
+                runAsUser: 1000  # Run as non-root user
+                runAsGroup: 1000  # Run as non-root group
+                privileged: false  # Do not run in privileged mode
               volumeMounts:
               - name: docker-socket
-                mountPath: /var/run/docker.sock
+                mountPath: /var/run/docker.sock  # Mount Docker socket volume
               env:
               - name: DOCKER_TLS_CERTDIR
-                value: ""
+                value: ""  # Disable TLS for Docker
               - name: DOCKER_HOST
-                value: "tcp://localhost:2375"
+                value: "tcp://localhost:2375"  # Set Docker host
               - name: DOCKER_DRIVER
-                value: "overlay2"
-      version: v3
+                value: "overlay2"  # Set Docker storage driver
+      version: v3  # Helm version to use
+
   destination:
-    server: https://kubernetes.default.svc
-    namespace: arc-runners-d-in-d
+    server: https://kubernetes.default.svc  # Kubernetes API server URL
+    namespace: arc-runners-d-in-d  # Namespace to deploy the application
+
   syncPolicy:
     automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+      prune: true  # Automatically prune resources that are no longer defined in the source
+      selfHeal: true  # Automatically sync if the cluster state changes
+      allowEmpty: false  # Do not allow empty application (no resources)
     syncOptions:
-    - Validate=false
-    - CreateNamespace=true
-    - ServerSideApply=true
+    - Validate=false  # Disable resource validation
+    - CreateNamespace=true  # Automatically create the target namespace if it doesn't exist
+    - ServerSideApply=true  # Use server-side apply for resource management
     retry:
-      limit: 5
+      limit: 5  # Number of retry attempts for failed syncs
       backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m
+        duration: 5s  # Initial backoff duration
+        factor: 2  # Backoff factor
+        maxDuration: 3m  # Maximum backoff duration

--- a/azure-east/arc-system/application-runner-scale-set-dind.yaml
+++ b/azure-east/arc-system/application-runner-scale-set-dind.yaml
@@ -54,11 +54,11 @@ spec:
               emptyDir: {}  # Create an empty directory volume for Docker socket (supports rootless mode)
             initContainers:
             - name: dind-rootless  # Name of the init container for DIND rootless
-              image: docker:20.10-dind-rootless  # Docker image for DIND rootless
+              image: docker:26.1-dind-rootless  # Docker image for DIND rootless
               securityContext:
                 runAsUser: 1000  # Run as non-root user
                 runAsGroup: 1000  # Run as non-root group
-                privileged: false  # Do not run in privileged mode
+                privileged: true  # Required for disabling seccomp, AppArmor, and mount masks
               volumeMounts:
               - name: docker-socket
                 mountPath: /var/run/docker.sock  # Mount Docker socket volume
@@ -69,6 +69,7 @@ spec:
                 value: "tcp://localhost:2375"  # Set Docker host
               - name: DOCKER_DRIVER
                 value: "overlay2"  # Set Docker storage driver
+              restartPolicy: Always  # Ensure the init container restarts if it fails
       version: v3  # Helm version to use
 
   destination:


### PR DESCRIPTION
The goal of this PR is to enable DinD [rootless](https://docs.docker.com/engine/security/rootless/) for customer testing.  This file was created from the original application-runner-scale-set.yaml.  Key Changes for Docker-in-Docker Rootless Mode:

1.  **Application Name and Namespace:**

- Changed name: arc-runner-set to name: arc-runners-d-in-d.
- Changed namespace: arc-runners to namespace: arc-runners-d-in-d.

2. **Runner Group:**

- Updated runnerGroup to arc-runners-d-in-d.

3. **Environment Variables:**

- Added DOCKER_HOST environment variable with the value tcp://localhost:2375.

4. **Volumes:**

- Added a docker-socket volume with emptyDir: {} to support rootless mode.

5. **Init Container:**

- Added an init container dind-rootless using the Docker-in-Docker rootless image docker:20.10-dind-rootless.
- Configured security context and environment variables for rootless Docker setup.

This should create a new set of action runners that use Docker-in-Docker in rootless mode.