### PR TITLE
Update application-runner-scale-set-dind.yaml

### DIFF
--- a/azure-east/arc-system/application-runner-scale-set-dind.yaml
+++ b/azure-east/arc-system/application-runner-scale-set-dind.yaml
@@ -47,28 +47,27 @@ spec:
                   mountPath: /home/runner/work  # Mount path for work directory
                 - name: docker-socket
                   mountPath: /var/run/docker.sock  # Mount path for Docker socket
+              - name: dind-rootless  # Name of the dind-rootless container
+                image: docker:26.1-dind-rootless  # Docker image for DIND rootless
+                securityContext:
+                  runAsUser: 1000  # Run as non-root user
+                  runAsGroup: 1000  # Run as non-root group
+                  privileged: true  # Required for disabling seccomp, AppArmor, and mount masks
+                volumeMounts:
+                - name: docker-socket
+                  mountPath: /var/run/docker.sock  # Mount Docker socket volume
+                env:
+                - name: DOCKER_TLS_CERTDIR
+                  value: ""  # Disable TLS for Docker
+                - name: DOCKER_HOST
+                  value: "tcp://localhost:2375"  # Set Docker host
+                - name: DOCKER_DRIVER
+                  value: "overlay2"  # Set Docker storage driver
             volumes:
             - name: work
               emptyDir: {}  # Create an empty directory volume for work
             - name: docker-socket
               emptyDir: {}  # Create an empty directory volume for Docker socket (supports rootless mode)
-            initContainers:
-            - name: dind-rootless  # Name of the init container for DIND rootless
-              image: docker:26.1-dind-rootless  # Docker image for DIND rootless
-              securityContext:
-                runAsUser: 1000  # Run as non-root user
-                runAsGroup: 1000  # Run as non-root group
-                privileged: true  # Required for disabling seccomp, AppArmor, and mount masks
-              volumeMounts:
-              - name: docker-socket
-                mountPath: /var/run/docker.sock  # Mount Docker socket volume
-              env:
-              - name: DOCKER_TLS_CERTDIR
-                value: ""  # Disable TLS for Docker
-              - name: DOCKER_HOST
-                value: "tcp://localhost:2375"  # Set Docker host
-              - name: DOCKER_DRIVER
-                value: "overlay2"  # Set Docker storage driver
       version: v3  # Helm version to use
 
   destination:


### PR DESCRIPTION
The issue with the current setup stems from the fact that the initContainer defined does not have a startup command, leading it to do nothing and blocking the startup of your other containers.  We need to remove the initContainer and have both the runner and dind-rootless containers start simultaneously